### PR TITLE
Add command-line option -s to active single-step mode

### DIFF
--- a/main.c
+++ b/main.c
@@ -12,20 +12,40 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+
+void output_usage(const char* executable_name) {
+	fprintf(stderr, "Nibbler - VM for Voja's 4-bit processor. Eats nibbles for breakfast.\n");
+	fprintf(stderr, "Usage: %s <[-s]> <file.bin>\n", executable_name);
+	fprintf(stderr, "  -s: start in step mode, default is to start running\n");
+}
 
 int main(int argc, char *argv[]) {
-	if (argc != 2) {
-		fprintf(stderr, "Nibbler - VM for Voja's 4-bit processor. Eats nibbles for breakfast.\n");
-		fprintf(stderr, "Usage: %s <file.bin>\n", argv[0]);
-		exit(1);
+	int opt;
+	int step_mode = 0;
+	while ((opt = getopt(argc, argv, "s")) != -1) {
+		switch (opt) {
+		case 's':
+			step_mode = 1;
+			break;
+		default:
+			output_usage(argv[0]);
+			exit(EXIT_FAILURE);
+		}
 	}
+
+	if (optind >= argc) {
+		output_usage(argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
 	size_t size;
-	void *buf = read_file(argv[1], &size);
+	void *buf = read_file(argv[optind], &size);
 	struct program *prg = load_program(buf, size);
 	if (!prg) {
 		exit(1);
 	}
-	vm_execute(prg);
+	vm_execute(prg, step_mode);
 	free(prg);
 
 	return 0;

--- a/ui.c
+++ b/ui.c
@@ -56,7 +56,7 @@ void finish(int sig)
 	exit(0);
 }
 
-void init_ui(struct ui *ui)
+void init_ui(struct ui *ui, int step_mode)
 {
 	memset(ui, 0, sizeof(struct ui));
 
@@ -99,6 +99,8 @@ void init_ui(struct ui *ui)
 	wrefresh(ui->status);
 	wtimeout(ui->status, 0);
 	keypad(ui->status, true);
+
+	ui->single_step = step_mode;
 }
 
 void exit_ui(struct ui *ui)

--- a/ui.h
+++ b/ui.h
@@ -23,7 +23,7 @@ struct ui {
 	bool single_step;
 };
 
-void init_ui(struct ui *ui);
+void init_ui(struct ui *ui, int step_mode);
 
 /* The UI can interact with the memory, e.g. to override the page register. */
 void update_ui(struct vm_state *vm, struct ui *ui);

--- a/vm.c
+++ b/vm.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 /* Clock periods in microseconds indexed by the value of the Clock register. */
@@ -101,14 +102,14 @@ void vm_update_user_sync(struct vm_state *vm)
 	}
 }
 
-void vm_execute(struct program *prg)
+void vm_execute(struct program *prg, int step_mode)
 {
 	struct vm_state *vm = calloc(1, sizeof(struct vm_state));
 	vm->prg = prg;
 	vm_init(vm);
 
 	struct ui ui;
-	init_ui(&ui);
+	init_ui(&ui, step_mode);
 
 	while (!ui.quit) {
 		vm_wait_cycle(vm);

--- a/vm.h
+++ b/vm.h
@@ -219,6 +219,6 @@ void vm_init(struct vm_state *vm);
 
 void vm_decode_next(const struct program *prog, struct vm_state *vm, struct vm_instruction *out);
 
-void vm_execute(struct program *prg);
+void vm_execute(struct program *prg, int step_mode);
 
 #endif /* _VM_H */


### PR DESCRIPTION
This adds a -s option using getopt to main and passes the flag down into the VM and UI code.  This pre-sets the UI single step mode so the code won't run immediately, but will be stopped on the first instruction