### PR TITLE
Check return value of getrandom

### DIFF
--- a/rng.c
+++ b/rng.c
@@ -67,7 +67,7 @@ uint8_t seed_to_nibble(uint32_t seed)
 uint8_t set_rng_seed(struct rng_state *rng, uint8_t seed)
 {
 	if (seed == RNG_USE_RANDOM_SEED) {
-		getrandom(&rng->seed, sizeof(rng->seed), 0 /* flags */);
+		while (sizeof(rng->seed) != getrandom(&rng->seed, sizeof(rng->seed), 0 /* flags */)) {}
 	} else {
 		rng->seed = seed_from_nibble(seed);
 	}


### PR DESCRIPTION
Because getrandom has attribute warn_unused_result, compilation will fail on some versions of GCC/glibc. According to the man page, this should never fail because we're using non-blocking getrandom and the seed size < 256 bytes, so add a simple loop that will call this until we get the right size.

Tested on Ubuntu 22.04 in WSL, compiled fine and ran test app.

Fixes issue #5