### PR TITLE
Add "red mode" for LED display

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@
  */
 
 #include "program.h"
+#include "ui.h"
 #include "vm.h"
 
 #include <stddef.h>
@@ -29,17 +30,21 @@
 
 void output_usage(const char* executable_name) {
 	fprintf(stderr, "Nibbler - VM for Voja's 4-bit processor. Eats nibbles for breakfast.\n");
-	fprintf(stderr, "Usage: %s <[-s]> <file.bin>\n", executable_name);
+	fprintf(stderr, "Usage: %s [-s] [-r] <file.bin>\n", executable_name);
 	fprintf(stderr, "  -s: start in step mode, default is to start running\n");
+	fprintf(stderr, "  -r: use red for page display to simulate LED color, default is gray\n");
 }
 
 int main(int argc, char *argv[]) {
 	int opt;
-	int step_mode = 0;
-	while ((opt = getopt(argc, argv, "s")) != -1) {
+	int ui_options = 0;
+	while ((opt = getopt(argc, argv, "sr")) != -1) {
 		switch (opt) {
 		case 's':
-			step_mode = 1;
+			ui_options |= STEP_MODE;
+			break;
+		case 'r':
+			ui_options |= RED_MODE;
 			break;
 		default:
 			output_usage(argv[0]);
@@ -59,7 +64,7 @@ int main(int argc, char *argv[]) {
 	if (!prg) {
 		exit(EXIT_FAILURE);
 	}
-	vm_execute(prg, step_mode);
+	vm_execute(prg, ui_options);
 	free(prg);
 
 	return EXIT_SUCCESS;

--- a/rng.c
+++ b/rng.c
@@ -67,7 +67,7 @@ uint8_t seed_to_nibble(uint32_t seed)
 uint8_t set_rng_seed(struct rng_state *rng, uint8_t seed)
 {
 	if (seed == RNG_USE_RANDOM_SEED) {
-		getrandom(&rng->seed, sizeof(rng->seed), 0 /* flags */);
+		while (sizeof(rng->seed) != getrandom(&rng->seed, sizeof(rng->seed), 0 /* flags */)) {}
 	} else {
 		rng->seed = seed_from_nibble(seed);
 	}

--- a/ui.c
+++ b/ui.c
@@ -129,10 +129,11 @@ void init_ui(struct ui *ui, int ui_options)
 		} else {
 			init_pair(P_PIXEL_OFF, COLOR_WHITE, COLOR_BLACK);
 			for (int i = 0; i < DIMMER_LEVELS; i++) {
-				if (red_mode)
+				if (red_mode) {
 					init_pair(P_PIXEL_DIM0 + i, COLOR_RED, COLOR_BLACK);
-				else
+				} else {
 					init_pair(P_PIXEL_DIM0 + i, COLOR_WHITE, COLOR_BLACK);
+				}
 			}
 		}
 	}

--- a/ui.c
+++ b/ui.c
@@ -85,7 +85,7 @@ void handle_signal(int sig)
 	}
 }
 
-void init_ui(struct ui *ui, int step_mode)
+void init_ui(struct ui *ui, int ui_options)
 {
 	memset(ui, 0, sizeof(struct ui));
 
@@ -106,6 +106,7 @@ void init_ui(struct ui *ui, int step_mode)
 	cbreak();
 
 	if (has_colors()) {
+		int red_mode = (ui_options & RED_MODE) == RED_MODE;
 		start_color();
 
 		if (can_change_color() && COLORS >= C_PIXEL_DIM0 + DIMMER_LEVELS) {
@@ -115,6 +116,10 @@ void init_ui(struct ui *ui, int step_mode)
 				short r = 1000 * (i + 1) / (DIMMER_LEVELS + 1);
 				short g = 1000 * (i + 1) / (DIMMER_LEVELS + 1);
 				short b = 1000 * (i + 1) / (DIMMER_LEVELS + 1);
+				if (red_mode) {
+					g = 0;
+					b = 0;
+				}
 				init_color(C_PIXEL_DIM0 + i, r, g, b);
 			}
 			init_pair(P_PIXEL_OFF, C_BACKGROUND, C_BACKGROUND);
@@ -124,7 +129,10 @@ void init_ui(struct ui *ui, int step_mode)
 		} else {
 			init_pair(P_PIXEL_OFF, COLOR_WHITE, COLOR_BLACK);
 			for (int i = 0; i < DIMMER_LEVELS; i++) {
-				init_pair(P_PIXEL_DIM0 + i, COLOR_WHITE, COLOR_BLACK);
+				if (red_mode)
+					init_pair(P_PIXEL_DIM0 + i, COLOR_RED, COLOR_BLACK);
+				else
+					init_pair(P_PIXEL_DIM0 + i, COLOR_WHITE, COLOR_BLACK);
 			}
 		}
 	}
@@ -139,7 +147,7 @@ void init_ui(struct ui *ui, int step_mode)
 	wtimeout(ui->status, 0);
 	keypad(ui->status, true);
 
-	ui->single_step = step_mode;
+	ui->single_step = (ui_options & STEP_MODE) == STEP_MODE;
 }
 
 void exit_ui(struct ui *ui)

--- a/ui.h
+++ b/ui.h
@@ -42,7 +42,10 @@ struct ui {
 	bool single_step;
 };
 
-void init_ui(struct ui *ui, int step_mode);
+#define STEP_MODE 1
+#define RED_MODE 2
+
+void init_ui(struct ui *ui, int ui_options);
 
 /* The UI can interact with the memory, e.g. to override the page register. */
 void update_ui(struct vm_state *vm, struct ui *ui);

--- a/vm.c
+++ b/vm.c
@@ -117,14 +117,17 @@ void vm_update_user_sync(struct vm_state *vm)
 	}
 }
 
-void vm_execute(struct program *prg, int step_mode)
+void vm_execute(struct program *prg, int ui_options)
 {
 	struct vm_state *vm = calloc(1, sizeof(struct vm_state));
 	vm->prg = prg;
 	vm_init(vm);
 
 	struct ui ui;
-	init_ui(&ui, step_mode);
+	init_ui(&ui, ui_options);
+
+	/* do one pass of UI so single-step mode will start on first instruction */
+	update_ui(vm, &ui);
 
 	while (!ui.quit) {
 		vm_wait_cycle(vm);

--- a/vm.h
+++ b/vm.h
@@ -245,6 +245,6 @@ void vm_init(struct vm_state *vm);
 
 void vm_decode_next(const struct program *prog, struct vm_state *vm, struct vm_instruction *out);
 
-void vm_execute(struct program *prg, int step_mode);
+void vm_execute(struct program *prg, int ui_options);
 
 #endif /* _VM_H */


### PR DESCRIPTION
This is activated with the -r switch. This makes the page
output show in red to emulate the red LEDs on the badge.

This also has a fix for single step mode to make it start
at PC 0, not PC 1.