### PR TITLE
Fix build error due to format warning

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -325,7 +325,7 @@ void maybe_update_status(const struct vm_state *vm, struct ui *ui)
 		disassemble_instruction(&vmi, descr, buf, sizeof(buf));
 		wmove(ui->status, row++, 1);
 		wprintw(ui->status, "%c%03hx:  %hhx%hhx%hhx  %-*s",
-			pc == vm->reg_pc ? '>' : ' ', pc, vmi.nibble1, vmi.nibble2, vmi.nibble3, sizeof(buf), buf);
+			pc == vm->reg_pc ? '>' : ' ', pc, vmi.nibble1, vmi.nibble2, vmi.nibble3, (int)sizeof(buf), buf);
 	}
 
 	wrefresh(ui->status);


### PR DESCRIPTION
Added a cast on sizeof(buf) to match expectation of width specifier in wprintw format string.

```
ui.c:327:64: error: field width specifier ‘*’ expects argument of type ‘int’, but argument 8 has type ‘long unsigned int’ [-Werror=format=]
  327 |                 wprintw(ui->status, "%c%03hx:  %hhx%hhx%hhx  %-*s",
      |                                                              ~~^~
      |                                                                |
      |                                                                int
  328 |                         pc == vm->reg_pc ? '>' : ' ', pc, vmi.nibble1, vmi.nibble2, vmi.nibble3, sizeof(buf), buf);
      |                                                                                                  ~~~~~~~~~~~
      |                                                                                                        |
      |                                                                                                        long unsigned int
cc1: all warnings being treated as errors
make: *** [Makefile:9: nibbler] Error 1
```